### PR TITLE
Upstream fixes

### DIFF
--- a/playbooks/roles/blktests/tasks/main.yml
+++ b/playbooks/roles/blktests/tasks/main.yml
@@ -206,7 +206,7 @@
 
 - name: Run blktests using ./oscheck.sh --print-done --test-group {{ group }} {{ oscheck_extra_args }}
   vars:
-    group: "{{ ansible_ssh_host | regex_replace('blktests-') | regex_replace(kdevops_host_prefix + '-') | regex_replace('-dev') | regex_replace('-', '_') }}"
+    group: "{{ ansible_host | regex_replace('blktests-') | regex_replace(kdevops_host_prefix + '-') | regex_replace('-dev') | regex_replace('-', '_') }}"
   tags: [ 'blktests', 'run_tests' ]
   become: yes
   become_flags: 'su - -c'

--- a/playbooks/roles/devconfig/templates/hostname
+++ b/playbooks/roles/devconfig/templates/hostname
@@ -1,1 +1,1 @@
-{{ ansible_ssh_host }}
+{{ ansible_host }}

--- a/playbooks/roles/fstests/tasks/main.yml
+++ b/playbooks/roles/fstests/tasks/main.yml
@@ -176,7 +176,7 @@
   become_method: sudo
   template:
     src: "{{ fstests_fstyp }}/{{ fstests_fstyp }}.config"
-    dest: "{{ fstests_data_target }}/configs/{{ ansible_ssh_host }}.config"
+    dest: "{{ fstests_data_target }}/configs/{{ ansible_host }}.config"
     force: yes
 
 - name: Reboot system before our test so we know everything is sane
@@ -229,7 +229,7 @@
 
 - name: Verify section name {{ fstests_section }} exists on fstests config file
   vars:
-    fstests_section: "{{ ansible_ssh_host | regex_replace(kdevops_host_prefix + '-') | regex_replace('-dev') | regex_replace('-', '_') }}"
+    fstests_section: "{{ ansible_host | regex_replace(kdevops_host_prefix + '-') | regex_replace('-dev') | regex_replace('-', '_') }}"
   tags: [ 'oscheck', 'fstests', 'run_tests', 'section' ]
   become: yes
   become_flags: 'su - -c'
@@ -237,7 +237,7 @@
   register: section_grep
   failed_when: not section_grep.changed
   lineinfile:
-    path: "{{ fstests_data_target }}/configs/{{ ansible_ssh_host }}.config"
+    path: "{{ fstests_data_target }}/configs/{{ ansible_host }}.config"
     regexp: "\\[{{ fstests_section }}\\]$"
     line: ''
   check_mode: yes
@@ -279,7 +279,7 @@
 
 - name: Check and verify fstests dependencies are met prior to running fstests
   vars:
-    fstests_section: "{{ ansible_ssh_host | regex_replace(kdevops_host_prefix + '-') | regex_replace('-dev') | regex_replace('-', '_') }}"
+    fstests_section: "{{ ansible_host | regex_replace(kdevops_host_prefix + '-') | regex_replace('-dev') | regex_replace('-', '_') }}"
   tags: [ 'oscheck', 'fstests', 'run_tests' ]
   become: yes
   become_flags: 'su - -c'
@@ -352,7 +352,7 @@
 
 - name: Run fstests using ./oscheck.sh --print-done --test-section {{ fstests_section }} {{ oscheck_extra_args }}
   vars:
-    fstests_section: "{{ ansible_ssh_host | regex_replace(kdevops_host_prefix + '-') | regex_replace('-dev') | regex_replace('-', '_') }}"
+    fstests_section: "{{ ansible_host | regex_replace(kdevops_host_prefix + '-') | regex_replace('-dev') | regex_replace('-', '_') }}"
   tags: [ 'oscheck', 'fstests', 'run_tests' ]
   become: yes
   become_flags: 'su - -c'

--- a/terraform/shared.tf
+++ b/terraform/shared.tf
@@ -80,5 +80,5 @@ data "template_file" "ansible_cmd" {
 
 locals {
   skip_ansible_cmd = "echo Skipping ansible provisioning"
-  ansible_cmd      = var.ansible_provision == "true" ? "${data.template_file.ansible_cmd.rendered}" : "${local.skip_ansible_cmd}"
+  ansible_cmd      = var.ansible_provision == "True" ? "${data.template_file.ansible_cmd.rendered}" : "${local.skip_ansible_cmd}"
 }


### PR DESCRIPTION
Hi,

This PR contains fixes for bugs that I came across when trying to get linux-kdevops to work with OCI. 

The first commit compares var.ansible_provision with "True" rather than "true". The second one replaces usage of the deprecated ansible_ssh_host variable with ansible_host.