### PR TITLE
Makefile:vagrant/Vagrantfile after extra_vars.yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,17 +68,6 @@ endif # CONFIG_NEEDS_LOCAL_DEVELOPMENT_PATH
 
 ANSIBLE_EXTRA_ARGS += $(LOCAL_DEVELOPMENT_ARGS)
 
-# We may not need the extra_args.yaml file all the time.  If this file is empty
-# you don't need it. All of our ansible kdevops roles check for this file
-# without you having to specify it as an extra_args=@extra_args.yaml file. This
-# helps us with allowing users call ansible on the command line themselves,
-# instead of using the make constructs we have built here.
-# Most of the ansible roles have extra_vars.yml as a dependency. Make sure this
-# is generated first by putting it first in DEFAULT_DEPS.
-ifneq (,$(ANSIBLE_EXTRA_ARGS))
-DEFAULT_DEPS += $(KDEVOPS_EXTRA_VARS)
-endif
-
 # These should be set as non-empty if you want any generic bring up
 # targets to come up. We support 2 bring up methods:
 #
@@ -100,7 +89,6 @@ endif # CONFIG_TERRAFORM
 
 ifeq (y,$(CONFIG_VAGRANT))
 include scripts/vagrant.Makefile
-DEFAULT_DEPS += $(KDEVOPS_VAGRANT)
 endif
 
 ifeq (y,$(CONFIG_WORKFLOWS))
@@ -115,6 +103,18 @@ ifeq (y,$(CONFIG_WORKFLOW_KOTD_ENABLE))
 include scripts/kotd.Makefile
 endif # WORKFLOW_KOTD_ENABLE
 
+# We may not need the extra_args.yaml file all the time.  If this file is empty
+# you don't need it. All of our ansible kdevops roles check for this file
+# without you having to specify it as an extra_args=@extra_args.yaml file. This
+# helps us with allowing users call ansible on the command line themselves,
+# instead of using the make constructs we have built here.
+ifneq (,$(ANSIBLE_EXTRA_ARGS))
+DEFAULT_DEPS += $(KDEVOPS_EXTRA_VARS)
+endif
+
+ifeq (y,$(CONFIG_VAGRANT))
+DEFAULT_DEPS += $(KDEVOPS_VAGRANT)
+endif
 
 DEFAULT_DEPS += $(DEFAULT_DEPS_REQS_EXTRA_VARS)
 


### PR DESCRIPTION
This reverts commit edee84363bc90612bf2235451b50678ea4c71d20.  "Makefile:
ensure extra_vars.yml is generated before vagrant/Vagrantfile" as it does
not place the extra_vars.yaml before vagrant/Vagrantfile target in the case
where the ANSIBLE_EXTRA_ARGS check is false.  We also make sure that
vagrant/Vagrantfile goes after extra_vars.yaml by adding a new
CONFIG_VAGRANT if condition after the one that adds the KDEVOPS_EXTRA_VARS.

Signed-off-by: Joel Granados <j.granados@samsung.com>