### PR TITLE
workflows: use "grep -E" instead of egrep in shell scripts

### DIFF
--- a/scripts/libvirt_pool.sh
+++ b/scripts/libvirt_pool.sh
@@ -42,7 +42,7 @@ virsh_works()
 
 virsh_get_pool_list()
 {
-	POOL_LIST=$($REQ_SUDO virsh pool-list| egrep -v "Name|\-\-\-\-\-"|  sed -e '/^$/d' | awk '{print $1}')
+	POOL_LIST=$($REQ_SUDO virsh pool-list| grep -E -v "Name|-----"|  sed -e '/^$/d' | awk '{print $1}')
 }
 
 virsh_path_in_pool_list_exists()

--- a/scripts/workflows/fstests/remove-common-failures.sh
+++ b/scripts/workflows/fstests/remove-common-failures.sh
@@ -41,7 +41,7 @@ done
 
 TMP_FILE=$(mktemp)
 for i in $FILES; do
-	cat $i | egrep -v "${COMMON_EXPUNGES[@]}" | sort | uniq > $TMP_FILE
+	cat $i | grep -E -v "${COMMON_EXPUNGES[@]}" | sort | uniq > $TMP_FILE
 	mv $TMP_FILE $i
 	SIZE=$(du -b $i | awk '{print $1}')
 	if [[ -d .git ]]; then

--- a/scripts/workflows/generic/run_kernel_ci.sh
+++ b/scripts/workflows/generic/run_kernel_ci.sh
@@ -238,7 +238,7 @@ kernel_ci_watchdog_loop()
 					cat $KERNEL_CI_WATCHDOG_TIMEOUT >> $KERNEL_CI_WATCHDOG_FAIL_LOG
 				fi
 				if [[ "$WATCHDOG_RESET_HUNG_SYSTEMS" == "y" ]]; then
-					for i in $(awk '{print $1}' $KERNEL_CI_WATCHDOG_RESULTS | egrep -v "runtime|Hostname"); do
+					for i in $(awk '{print $1}' $KERNEL_CI_WATCHDOG_RESULTS | grep -E -v "runtime|Hostname"); do
 						sudo virsh reset vagrant_$i
 						echo -e "\nReset all your associated systems:" >> $KERNEL_CI_WATCHDOG_FAIL_LOG
 						echo -e "\t$i" >> $KERNEL_CI_WATCHDOG_FAIL_LOG


### PR DESCRIPTION
I'm getting warnings about egrep being deprecated and about extraneous '\' chars in the regex. Switch to grep -E and drop the unneeded escapes.