### PR TITLE
Adding ansible-playbook dependency check step

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ your distribution of choice, enable the Linux kernel workflow, select target
 git tree, and get up and running on a freshly compiled Linux git tree in just
 4 commands:
 
+  * optional : `./scripts/check_ansible.sh`
   * `make menuconfig`
   * `make`
   * `make bringup`

--- a/scripts/check_ansible.sh
+++ b/scripts/check_ansible.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if which ansible-playbook >/dev/null; then
+    echo "ansible existed"
+else
+    if which pip > /dev/null; then
+    	echo "Start to install ansible"
+		pip install ansible
+    	echo "Ansible installed"
+	else
+		echo "install pip befoer starting this script"
+	fi
+fi

--- a/scripts/check_ansible.sh
+++ b/scripts/check_ansible.sh
@@ -5,9 +5,9 @@ if which ansible-playbook >/dev/null; then
 else
     if which pip > /dev/null; then
     	echo "Start to install ansible"
-		pip install ansible
+	pip install ansible
     	echo "Ansible installed"
-	else
-		echo "install pip befoer starting this script"
-	fi
+    else
+	echo "install pip befoer starting this script"
+    fi
 fi


### PR DESCRIPTION
Currently, without ansible-playbook in system, quick-start commands set (make) will fail.
I added script for check/install ansible and updated the README.md.

Signed-off-by: Dongjoo Seo [dongjoo1.seo@samsung.com](mailto:dongjoo1.seo@samsung.com)